### PR TITLE
Excel.ConvertToXML - Fixed issue with similar sheet names

### DIFF
--- a/Frends.Excel.ConvertToXML/CHANGELOG.md
+++ b/Frends.Excel.ConvertToXML/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.2] - 2023-08-01
+### Fixed
+- Fixed Options.ShouldReadSheet method to check if the Sheet name equals to the given name.
+
 ## [1.0.1] - 2022-08-10
 ### Change
 - Documentation updates

--- a/Frends.Excel.ConvertToXML/Frends.Excel.ConvertToXML/Definitions/Options.cs
+++ b/Frends.Excel.ConvertToXML/Frends.Excel.ConvertToXML/Definitions/Options.cs
@@ -50,7 +50,7 @@ public class Options
     {
         if (string.IsNullOrWhiteSpace(ReadOnlyWorkSheetWithName))
             return true;
-        if (ReadOnlyWorkSheetWithName.Contains(sheetName))
+        if (ReadOnlyWorkSheetWithName.Equals(sheetName))
             return true;
 
         return false;

--- a/Frends.Excel.ConvertToXML/Frends.Excel.ConvertToXML/Frends.Excel.ConvertToXML.csproj
+++ b/Frends.Excel.ConvertToXML/Frends.Excel.ConvertToXML/Frends.Excel.ConvertToXML.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Frends</Authors>
 		<Copyright>Frends</Copyright>
 		<Company>Frends</Company>


### PR DESCRIPTION
#20 
- Fixed Options.ShouldReadSheet method to check if the Sheet name equals to the given name.