### PR TITLE
Newtonsoft.Json library update

### DIFF
--- a/Frends.Excel.ConvertToJSON/CHANGELOG.md
+++ b/Frends.Excel.ConvertToJSON/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2024-08-21
+### Changed
+- Updated the Newtonsoft.Json package to the latest version.
+
 ## [2.0.0] - 2023-03-21
 ### Changed
 - Change how the Json is constructed.

--- a/Frends.Excel.ConvertToJSON/Frends.Excel.ConvertToJSON/Frends.Excel.ConvertToJSON.csproj
+++ b/Frends.Excel.ConvertToJSON/Frends.Excel.ConvertToJSON/Frends.Excel.ConvertToJSON.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Frends</Authors>
     <Copyright>Frends</Copyright>
     <Company>Frends</Company>
@@ -30,7 +30,7 @@
     <None Remove="ExcelDataReader" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />
     <PackageReference Include="ExcelDataReader" Version="3.6.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.0.43782">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Frends.Excel
 
-Frends tasks for regular expressions.
+Frends tasks for Excel.
 
 # Tasks
 


### PR DESCRIPTION
closes #25 

Updated the library flagged by Dependabot. Also fixed a typo in the Readme, which said regex instead of excel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Newtonsoft.Json package to version 13.0.3, enhancing JSON conversion capabilities.
  
- **Documentation**
	- Revised the README to clarify focus on Excel tasks rather than regular expressions.

- **Chores**
	- Incremented project version from 2.0.0 to 2.1.0, ensuring updated dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->